### PR TITLE
IGeometryGrid API Update, Python Fixes, MXA Removal

### DIFF
--- a/SimulationIOFilters/CreateFEAInputFiles.cpp
+++ b/SimulationIOFilters/CreateFEAInputFiles.cpp
@@ -322,12 +322,9 @@ void CreateFEAInputFiles::execute()
 
     DataContainer::Pointer m = getDataContainerArray()->getDataContainer(getAbqFeatureIdsArrayPath().getDataContainerName());
 
-    size_t dims[3] = {0, 0, 0};
-    std::tie(dims[0], dims[1], dims[2]) = m->getGeometryAs<ImageGeom>()->getDimensions();
-    FloatVec3Type spacing;
-    m->getGeometryAs<ImageGeom>()->getSpacing(spacing);
-    FloatVec3Type origin;
-    m->getGeometryAs<ImageGeom>()->getOrigin(origin);
+    SizeVec3Type dims = m->getGeometryAs<ImageGeom>()->getDimensions();
+    FloatVec3Type spacing = m->getGeometryAs<ImageGeom>()->getSpacing();
+    FloatVec3Type origin = m->getGeometryAs<ImageGeom>()->getOrigin();
     //
     // find total number of Grain Ids
     int32_t maxGrainId = 0;
@@ -606,12 +603,9 @@ void CreateFEAInputFiles::execute()
 
     DataContainer::Pointer m = getDataContainerArray()->getDataContainer(getPzflexFeatureIdsArrayPath().getDataContainerName());
 
-    size_t dims[3] = {0, 0, 0};
-    std::tie(dims[0], dims[1], dims[2]) = m->getGeometryAs<ImageGeom>()->getDimensions();
-    FloatVec3Type spacing;
-    m->getGeometryAs<ImageGeom>()->getSpacing(spacing);
-    FloatVec3Type origin;
-    m->getGeometryAs<ImageGeom>()->getOrigin(origin);
+    SizeVec3Type dims = m->getGeometryAs<ImageGeom>()->getDimensions();
+    FloatVec3Type spacing = m->getGeometryAs<ImageGeom>()->getSpacing();
+    FloatVec3Type origin = m->getGeometryAs<ImageGeom>()->getOrigin();
     //
     // find total number of Grain Ids
     int32_t maxGrainId = 0;

--- a/SimulationIOFilters/ExportDAMASKFiles.cpp
+++ b/SimulationIOFilters/ExportDAMASKFiles.cpp
@@ -220,12 +220,9 @@ void ExportDAMASKFiles::execute()
   //
   DataContainer::Pointer m = getDataContainerArray()->getDataContainer(getFeatureIdsArrayPath().getDataContainerName());
 
-  size_t dims[3] = {0, 0, 0};
-  std::tie(dims[0], dims[1], dims[2]) = m->getGeometryAs<ImageGeom>()->getDimensions();
-  FloatVec3Type spacing;
-  m->getGeometryAs<ImageGeom>()->getSpacing(spacing);
-  FloatVec3Type origin;
-  m->getGeometryAs<ImageGeom>()->getOrigin(origin);
+  SizeVec3Type dims = m->getGeometryAs<ImageGeom>()->getDimensions();
+  FloatVec3Type spacing = m->getGeometryAs<ImageGeom>()->getSpacing();
+  FloatVec3Type origin = m->getGeometryAs<ImageGeom>()->getOrigin();
   float size[3] = {0.0f, 0.0f, 0.0f};
 
   for(int32_t i = 0; i < 3; i++)

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -58,7 +58,7 @@ if(SIMPL_ENABLE_PYTHON)
         configure_file(${SIMPL_PYTHON_TEST_SCRIPT}
                         "${SIMPL_PYTHON_TEST_DRIVER}" @ONLY)
 
-        add_test(NAME ${PLUGIN_NAME}_${test} COMMAND "${SIMPL_PYTHON_TEST_DRIVER}" )
+        add_test(NAME PY_${PLUGIN_NAME}_${test} COMMAND "${SIMPL_PYTHON_TEST_DRIVER}" )
     endforeach(test ${PLUGIN_PYTHON_TESTS})
     #------------------------------
     # Also setup a unit test for the base python unit test file that is generated as part
@@ -67,7 +67,7 @@ if(SIMPL_ENABLE_PYTHON)
     set(SIMPL_PYTHON_TEST_DRIVER "${SIMPL_ANACONDA_OUTPUT_DIR}/UnitTest/${PLUGIN_NAME}/${PLUGIN_NAME}.sh")
     set(test "${PLUGIN_NAME}_UnitTest")
     configure_file(${SIMPL_PYTHON_TEST_SCRIPT}  "${SIMPL_PYTHON_TEST_DRIVER}" @ONLY)
-    add_test(NAME ${PLUGIN_NAME}_Python_UnitTest COMMAND "${SIMPL_PYTHON_TEST_DRIVER}" )
+    add_test(NAME PY_${PLUGIN_NAME}_UnitTest COMMAND "${SIMPL_PYTHON_TEST_DRIVER}" )
 endif()
 
 

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -44,7 +44,7 @@ if(SIMPL_ENABLE_PYTHON)
 
     #------------------------------
     # Initialize the PYTHON_TEST_INPUT_DIR variable to point to the "Testing Directory"
-    file(TO_CMAKE_PATH "${${PLUGIN_NAME}Test_SOURCE_DIR}/Python" PYTHON_TEST_INPUT_DIR)
+    file(TO_NATIVE_PATH "${${PLUGIN_NAME}Test_SOURCE_DIR}/Python" PYTHON_TEST_INPUT_DIR)
     #------------------------------
     # These names should match the names "EXACTLY" (including capitalization).
     # NO Spaces in the names (which means no spaces in the variable names)
@@ -68,7 +68,7 @@ if(SIMPL_ENABLE_PYTHON)
     # Also setup a unit test for the base python unit test file that is generated as part
     # of the Pybind11 generated codes
     set(PYTHON_TEST_INPUT_DIR "${SIMPL_ANACONDA_OUTPUT_DIR}/UnitTest/${PLUGIN_NAME}")
-    set(SIMPL_PYTHON_TEST_DRIVER "${SIMPL_ANACONDA_OUTPUT_DIR}/UnitTest/${PLUGIN_NAME}/${PLUGIN_NAME}.sh")
+    set(SIMPL_PYTHON_TEST_DRIVER "${SIMPL_ANACONDA_OUTPUT_DIR}/UnitTest/${PLUGIN_NAME}/${PLUGIN_NAME}.${TEST_SCRIPT_FILE_EXT}")
     set(test "${PLUGIN_NAME}_UnitTest")
     configure_file(${SIMPL_PYTHON_TEST_SCRIPT}  "${SIMPL_PYTHON_TEST_DRIVER}" @ONLY)
     add_test(NAME PY_${PLUGIN_NAME}_UnitTest COMMAND "${SIMPL_PYTHON_TEST_DRIVER}" )

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -52,8 +52,12 @@ if(SIMPL_ENABLE_PYTHON)
 
     )
 
+    set(TEST_SCRIPT_FILE_EXT "sh")
+    if(WIN32)
+      set(TEST_SCRIPT_FILE_EXT "bat")
+    endif()
     foreach(test ${PLUGIN_PYTHON_TESTS})
-        set(SIMPL_PYTHON_TEST_DRIVER "${SIMPL_ANACONDA_OUTPUT_DIR}/UnitTest/${PLUGIN_NAME}/${test}.sh")
+        set(SIMPL_PYTHON_TEST_DRIVER "${SIMPL_ANACONDA_OUTPUT_DIR}/UnitTest/${PLUGIN_NAME}/${test}.${TEST_SCRIPT_FILE_EXT}")
 
         configure_file(${SIMPL_PYTHON_TEST_SCRIPT}
                         "${SIMPL_PYTHON_TEST_DRIVER}" @ONLY)

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -35,3 +35,39 @@ SIMPL_GenerateUnitTestFile(PLUGIN_NAME ${PLUGIN_NAME}
                                         ${${PLUGIN_NAME}_PARENT_BINARY_DIR}
 )
 
+#------------------------------------------------------------------------------
+# If Python is enabled, then enable the Python unit tests for this plugin
+if(SIMPL_ENABLE_PYTHON)
+    get_property(SIMPL_ANACONDA_OUTPUT_DIR GLOBAL PROPERTY SIMPL_ANACONDA_OUTPUT_DIR)
+    get_property(SIMPL_PYTHON_TEST_SCRIPT GLOBAL PROPERTY SIMPL_PYTHON_TEST_SCRIPT)
+    get_property(PYTHON_SITE_PACKAGES_NAME GLOBAL PROPERTY PYTHON_SITE_PACKAGES_NAME)
+
+    #------------------------------
+    # Initialize the PYTHON_TEST_INPUT_DIR variable to point to the "Testing Directory"
+    file(TO_CMAKE_PATH "${${PLUGIN_NAME}Test_SOURCE_DIR}/Python" PYTHON_TEST_INPUT_DIR)
+    #------------------------------
+    # These names should match the names "EXACTLY" (including capitalization).
+    # NO Spaces in the names (which means no spaces in the variable names)
+    set(PLUGIN_PYTHON_TESTS
+
+    )
+
+    foreach(test ${PLUGIN_PYTHON_TESTS})
+        set(SIMPL_PYTHON_TEST_DRIVER "${SIMPL_ANACONDA_OUTPUT_DIR}/UnitTest/${PLUGIN_NAME}/${test}.sh")
+
+        configure_file(${SIMPL_PYTHON_TEST_SCRIPT}
+                        "${SIMPL_PYTHON_TEST_DRIVER}" @ONLY)
+
+        add_test(NAME ${PLUGIN_NAME}_${test} COMMAND "${SIMPL_PYTHON_TEST_DRIVER}" )
+    endforeach(test ${PLUGIN_PYTHON_TESTS})
+    #------------------------------
+    # Also setup a unit test for the base python unit test file that is generated as part
+    # of the Pybind11 generated codes
+    set(PYTHON_TEST_INPUT_DIR "${SIMPL_ANACONDA_OUTPUT_DIR}/UnitTest/${PLUGIN_NAME}")
+    set(SIMPL_PYTHON_TEST_DRIVER "${SIMPL_ANACONDA_OUTPUT_DIR}/UnitTest/${PLUGIN_NAME}/${PLUGIN_NAME}.sh")
+    set(test "${PLUGIN_NAME}_UnitTest")
+    configure_file(${SIMPL_PYTHON_TEST_SCRIPT}  "${SIMPL_PYTHON_TEST_DRIVER}" @ONLY)
+    add_test(NAME ${PLUGIN_NAME}_Python_UnitTest COMMAND "${SIMPL_PYTHON_TEST_DRIVER}" )
+endif()
+
+


### PR DESCRIPTION
The API is changed to use a FloatVec3Type or SizeVec3Type (both alias for SIMPLArray<T, N>) so that
the API is consistent among the various classes and easy to use within SIMPL/DREAM.3D and its plugins.
The use of the std::tuple based return types is deprecated and removed.

The Python script files were completely reorganized to put the scripts with their plugins. Most of
the scripts were tested on a macOS machine and added to the ctest suite of unit tests. For each script
a bash script is created that drives the test. The Python tests are dependant on an Anaconda3 installation
being used. A few of the Python tests are still failing but those will be fixed eventually

The source code was searched for the old and deprecated MXA strings and classes and the old code was
either removed or renamed to SIMPL.

Signed-off-by: Michael Jackson mike.jackson@bluequartz.net